### PR TITLE
Revert change to use an absolute path for targetEntry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ module.exports = class InitializeEntryPlugin {
 
                 else if(result.request == "__webpack_entry__"){
                     const requestedBy = result.contextInfo.issuer;
-                    const targetEntry = this.importPassTo[requestedBy];
+                    const targetEntry = this.importPassTo['./' + path.relative(this.context!, requestedBy)];
 
                     if(!targetEntry)
                         throw new Error(`Module '__webpack_entry__' was requested by ${requestedBy} but that module is not an initializer!`)


### PR DESCRIPTION
Here's the error I'm trying to avoid.

```
$ npm run build
new
Hash: 0283084334db73d78042
Version: webpack 4.17.1
Time: 88ms
Built at: 08/14/2019 3:16:04 PM
      Asset      Size  Chunks             Chunk Names
 ./multi.js  4.62 KiB   multi  [emitted]  multi
./single.js  4.14 KiB  single  [emitted]  single
Entrypoint single = ./single.js
Entrypoint multi = ./multi.js
[./bar.intermediate.js] 59 bytes {multi} [built]
[./foo.js] 17 bytes {multi} [built]
[0] multi ./foo.js ./bar.js 40 bytes {multi} [built]
[./hello.intermediate.js] 59 bytes {single} [built]

ERROR in ./bar.intermediate.js
Module not found: Error: Module '__webpack_entry__' was requested by /Users/cb/Projects/webpack-intermediate-entry/example/src/bar.intermediate.js but that module is not an initializer!
 @ ./bar.intermediate.js 1:0-38 3:12-17
 @ multi ./foo.js ./bar.js

ERROR in ./hello.intermediate.js
Module not found: Error: Module '__webpack_entry__' was requested by /Users/cb/Projects/webpack-intermediate-entry/example/src/hello.intermediate.js but that module is not an initializer!
 @ ./hello.intermediate.js 1:0-38 3:12-17
```

I get this after cloning this repo, running `npm install` in the project root and in the example folder, then running `npm run build` in the example folder. I get the same error when trying to run this in my own project.

I tried a few older versions of this library, back when it was called `webpack-intialize-entry`, and found [the change](https://github.com/gabeklein/webpack-intermediate-entry/commit/82fbcd18d3cb677e6efabb93590410fedc26f2cc) that seemed to introduce the issue for me. I not going to pretend to actually understand what's going on here, but reverting this line seems to fix it.